### PR TITLE
added endpoint for manual check: get hit from top unmarked worker

### DIFF
--- a/app/controllers/api/hit_controller.rb
+++ b/app/controllers/api/hit_controller.rb
@@ -37,6 +37,18 @@ module Api
       render json: result
     end
 
+    def s1_get_by_worker_unmarked
+      # choose random hit from worker with most unmarked hits
+      worker = Worker.find_by_sql("
+        SELECT * FROM workers
+        ORDER BY (hit_submits - good_s1_count - bad_s1_count) DESC
+      ").first
+      render json: {
+        hit: Hit.where(worker_id: worker.id, eval: nil).sample,
+        worker: worker
+      }
+    end
+
     def return_s1_info
       render json: {
         total: Hit.all.count,
@@ -83,7 +95,7 @@ module Api
     def hit_getter_helper(eval_status)
       candidates = Hit.where.missing(:explanation)
       candidates = candidates.where(eval: eval_status == 'null' ? nil : eval_status)
-      candidates.order(Arel.sql('RANDOM()')).first
+      candidates.sample
     end
 
     def update_worker_s1_counts(worker_id, old_eval, new_eval, amt)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     get '/get_hit_metrics', action: :return_s1_info, controller: :hit
     post '/eval_hit/:hit_id/:new_eval_field', action: :update_hit_eval, controller: :hit
     post '/eval_all_s1_by/:worker_id/:new_status', action: :eval_all_s1_by, controller: :hit
+    get '/get_s1_ordered', action: :s1_get_by_worker_unmarked, controller: :hit
 
     get '/get_explanations/:worker_id', action: :worker_explanations, controller: :explanation
     post '/add_explanation', action: :add_explanation, controller: :explanation


### PR DESCRIPTION
To take advantage of "mark all by this worker" button, added a new endpoint that always gets a random hit from the worker with the most unmarked hits.

The idea is that we can sample a bunch from the top worker, and then pass all of their work.